### PR TITLE
Add "via" and "hashtags" to twitter

### DIFF
--- a/sharer.js
+++ b/sharer.js
@@ -61,7 +61,9 @@
                         shareUrl = 'https://twitter.com/intent/tweet/';
                         params = {
                             text: that.getValue('data-title'),
-                            url: that.getValue('data-url')
+                            url: that.getValue('data-url'),
+                            via: that.getValue('data-via'),
+                            hashtags: that.getValue('data-hashtags')
                         };
                         that.urlSharer(shareUrl, params);
                     },


### PR DESCRIPTION
https://twitter.com/intent/tweet supports a "via" parameter (without the @) and "hashtags" (comma separated)