### PR TITLE
changed sharer data to all lowercase when mapping

### DIFF
--- a/sharer.js
+++ b/sharer.js
@@ -36,7 +36,7 @@
          * based on the data-sharer attribute.
          */
         share: function() {
-            var sharer = this.getValue('sharer'),
+            var sharer = this.getValue('sharer').toLowerCase(),
                 that = this,
                 shareUrl,
                 params,


### PR DESCRIPTION
The value of the `sharer` variable is determined by the value of `data-sharer` attribute on an element, and if that value happens to have any uppercase letters, then the `sharers` map will not link correctly.

Basically, when this line is called:

    return (sharers[sharer] || sharers['default'])();

If the user sets `share` to "Facebook" instead of "facebook" then we'll have problems because `sharers['Facebook'] =/= sharers['facebook']`