### PR TITLE
remove duplicated subject in email body

### DIFF
--- a/sharer.js
+++ b/sharer.js
@@ -66,7 +66,7 @@
                         shareUrl: 'mailto:' + this.getValue('to'),
                         params: {
                             subject: this.getValue('subject'),
-                            body: this.getValue('subject') + '\n'+ this.getValue('title') + '\n' + this.getValue('url')
+                            body: this.getValue('title') + '\n' + this.getValue('url')
                         },
                         isLink: true
                     },


### PR DESCRIPTION
It looks weird we have duplicated subject in email body:

![image](https://cloud.githubusercontent.com/assets/96356/13202472/3023390e-d8d7-11e5-913e-fcd17e465714.png)
