### PR TITLE
pass a default value

### DIFF
--- a/sharer.js
+++ b/sharer.js
@@ -51,11 +51,13 @@
          *  @function getValue
          *  @description Helper to get the attribute of a DOM element
          *  @param {String} attr DOM element attribute
+         *  @param {String} defaultValue value to use for attr
          *  @returns {String|Empty} returns the attr value or empty string
          */
-        getValue: function(attr) {
+        getValue: function(attr, defaultValue) {
+            defaultValue = (defaultValue === undefined) ? '' : defaultValue;
             var val = this.elem.getAttribute('data-' + attr);
-            return (val === undefined || val === null) ? false : val;
+            return (val === undefined || val === null) ? defaultValue : val;
         },
 
         /**


### PR DESCRIPTION
Problem:
When using the "Email" sharing and you don't set a `data-to` attribute. The sharer will set it to false when your email client pop ups.

<img width="457" alt="screen shot 2017-06-29 at 9 43 25 pm" src="https://user-images.githubusercontent.com/4613374/27721282-3853d5bc-5d14-11e7-8eb2-a734b0fd401f.png">


First approach was to change the `false` to a `''`. But then I ran into another problem where I wanted to pass a default value when the attribute came back empty.
