### PR TITLE
StumbleUpon has moved to Mix.

### DIFF
--- a/sharer.js
+++ b/sharer.js
@@ -208,11 +208,17 @@
                             url: this.getValue('url')
                         }
                     },
-                    stumbleupon: {
+                    stumbleupon: {	// Usage deprecated, leaving for backwards compatibility.
                         shareUrl: 'http://www.stumbleupon.com/submit',
                         params: {
                             url: this.getValue('url'),
                             title: this.getValue('title')
+                        }
+                    },
+                    mix: {
+                        shareUrl: 'https://mix.com/add',
+                        params: {
+                            url: this.getValue('url')
                         }
                     },
                     flipboard: {


### PR DESCRIPTION
- Added Mix service to sharer.
- Left StumbleUpon to backwards compatability but commented usage to be deprecated.