### PR TITLE
Update twitter shareUrl

### DIFF
--- a/sharer.js
+++ b/sharer.js
@@ -88,7 +88,7 @@
             },
           },
           twitter: {
-            shareUrl: 'https://twitter.com/intent/tweet/',
+            shareUrl: 'https://twitter.com/intent/tweet',
             params: {
               text: this.getValue('title'),
               url: this.getValue('url'),


### PR DESCRIPTION
For now, if keep the `/`, i can't see the login form popup if I haven't logged in to twitter.
If I remove the `/`, when I don't login to twitter, then click on the Twiiter button in my app, I can see the login form popup on twitter
![image](https://user-images.githubusercontent.com/89009518/210036745-7f84621f-f000-4cbf-9e14-de24b30d7807.png)
![image](https://user-images.githubusercontent.com/89009518/210036763-b44d720f-f341-4161-8a80-5a52595e787b.png)
 