### PR TITLE
Docs: Made the 'Back to top' button to be visible always

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -569,7 +569,7 @@ $(elem).on('click', function() {
 
       <footer class="site-footer">
         <span class="site-footer-owner"><a href="https://github.com/ellisonleao/sharer.js">Sharer.js</a> is maintained by <a href="https://github.com/ellisonleao">ellisonleao</a>.</span>
-        <p> <a href="#available-sharer-components">Back to top</a> </p>
+        <p class="back-to-top"> <a href="#available-sharer-components">Back to top</a> </p>
       </footer>
 
     </section>

--- a/docs/stylesheets/stylesheet.css
+++ b/docs/stylesheets/stylesheet.css
@@ -246,3 +246,9 @@ a {
 @media screen and (max-width: 42em) {
   .site-footer {
     font-size: 0.9rem; } }
+
+.back-to-top {
+  position: fixed;
+  bottom: 1rem;
+  right: 2rem;
+}


### PR DESCRIPTION
In documentation page, there is a "Back to top" button. This button doesn't shows up until the user reaches the bottom. Since the doc page is very long, it takes a lot of time to scroll back to the top if the user has reached midway. 

It would be a good user experience, if the "Back to Top" button is made available to the user throughout the time they are scrolling through the website. 

With this PR, I have tried to make this button fixed on the bottom right corner.
<img width="1277" height="520" alt="Screenshot Capture - 2025-08-29 - 23-16-05" src="https://github.com/user-attachments/assets/d301f070-1a4b-4a04-ac68-a5536d3adf7a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Introduced a “back-to-top” UI element styled to be fixed at the bottom-right corner of the viewport for easier access while scrolling on documentation pages.

* **Documentation**
  * Updated the footer’s “Back to top” link markup to include a class for the new styling. No content or structural changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->