### PR TITLE
Refactor parameters for odnoklassniki sharing

### DIFF
--- a/sharer.js
+++ b/sharer.js
@@ -339,11 +339,9 @@
           odnoklassniki: {
             shareUrl: 'https://connect.ok.ru/dk',
             params: {
-              st: {
-                cmd: 'WidgetSharePreview',
-                deprecated: 1,
-                shareUrl: this.getValue('url'),
-              },
+              'st.cmd': 'WidgetSharePreview',
+              'st.deprecated': 1,
+              'st.shareUrl': this.getValue('url'),
             },
           },
           meneame: {


### PR DESCRIPTION
I think currently it leads to `?st=%5Bobject%20Object%5D`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Ok.ru (Odnoklassniki) sharing functionality to properly format parameters in the sharing URL, ensuring the share action works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->